### PR TITLE
Updated comments and  ensured all vars clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This is a workspace control for demo environment. You can use this, as well as t
 ## Consul Demo Workspace
  resource "tfe_workspace" "aws_consul_demo_setup" {
    name         = "aws-consul-demo"
-   organization = var.org_name
+   organization = var.tfe_org_name
    queue_all_runs = false
    vcs_repo {
      identifier     = "someusername/consul-aws-demo"
      branch         = "master"
-     oauth_token_id = var.oauth_token_id
+     oauth_token_id = var.tfe_oauth_token_id
   }
 }
 ```

--- a/aws-terraform-demo.tf
+++ b/aws-terraform-demo.tf
@@ -2,18 +2,18 @@
 
 resource "tfe_workspace" "aws_terraform_demo_setup" {
   name           = "aws-terraform-demo"
-  organization   = var.org_name
+  organization   = var.tfe_org_name
   queue_all_runs = false
   vcs_repo {
-    identifier     = "mtharpe/terraform-aws-demo"
+    identifier     = "${var.tfe_vcs_username}/terraform-aws-demo"
     branch         = "master"
-    oauth_token_id = var.oauth_token_id
+    oauth_token_id = var.tfe_oauth_token_id
   }
 }
 
 resource "tfe_variable" "aws_tfe_user" {
   key          = "user"
-  value        = var.org_name
+  value        = var.tfe_org_name
   category     = "terraform"
   workspace_id = tfe_workspace.aws_terraform_demo_setup.id
   description  = "TFE ORG User"

--- a/azure-terraform-demo.tf
+++ b/azure-terraform-demo.tf
@@ -2,12 +2,12 @@
 
 resource "tfe_workspace" "azure_terraform_demo_setup" {
   name           = "azure-terraform-demo"
-  organization   = var.org_name
+  organization   = var.tfe_org_name
   queue_all_runs = false
   vcs_repo {
-    identifier     = "mtharpe/terraform-azure-demo"
+    identifier     = "${var.tfe_vcs_username}/terraform-azure-demo"
     branch         = "master"
-    oauth_token_id = var.oauth_token_id
+    oauth_token_id = var.tfe_oauth_token_id
   }
 }
 

--- a/gcp-terraform-demo.tf
+++ b/gcp-terraform-demo.tf
@@ -2,12 +2,12 @@
 
 resource "tfe_workspace" "gcp_terraform_demo_setup" {
   name           = "gcp-terraform-demo"
-  organization   = var.org_name
+  organization   = var.tfe_org_name
   queue_all_runs = false
   vcs_repo {
-    identifier     = "mtharpe/terraform-gcp-demo"
+    identifier     = "${var.tfe_vcs_username}/terraform-gcp-demo"
     branch         = "master"
-    oauth_token_id = var.oauth_token_id
+    oauth_token_id = var.tfe_oauth_token_id
   }
 }
 

--- a/sentinel.tf
+++ b/sentinel.tf
@@ -11,5 +11,5 @@ resource "tfe_policy_set" "base_policy_set" {
   description   = "This policy set holds base policy"
   organization  = var.tfe_org_name
   policy_ids    = [tfe_sentinel_policy.base_policy.id]
-  workspace_ids = [tfe_workspace.aws_terraform_demo_setup.id, tfe_workspace.azure_terraform_demo_setup.id, tfe_workspace.gcp_terraform_demo_setup.id ]
+  workspace_ids = [tfe_workspace.aws_terraform_demo_setup.id, tfe_workspace.azure_terraform_demo_setup.id, tfe_workspace.gcp_terraform_demo_setup.id]
 }

--- a/sentinel.tf
+++ b/sentinel.tf
@@ -1,7 +1,7 @@
 resource "tfe_sentinel_policy" "base_policy" {
   name         = "base_policy"
   description  = "This policy always passes"
-  organization = var.org_name
+  organization = var.tfe_org_name
   policy       = "main = rule { true }"
   enforce_mode = "hard-mandatory"
 }
@@ -9,7 +9,7 @@ resource "tfe_sentinel_policy" "base_policy" {
 resource "tfe_policy_set" "base_policy_set" {
   name          = "base_policy_set"
   description   = "This policy set holds base policy"
-  organization  = var.org_name
-  policy_ids    = ["${tfe_sentinel_policy.base_policy.id}"]
-  workspace_ids = ["${tfe_workspace.aws_terraform_demo_setup.id}", "${tfe_workspace.azure_terraform_demo_setup.id}", "${tfe_workspace.gcp_terraform_demo_setup.id}", ]
+  organization  = var.tfe_org_name
+  policy_ids    = [tfe_sentinel_policy.base_policy.id]
+  workspace_ids = [tfe_workspace.aws_terraform_demo_setup.id, tfe_workspace.azure_terraform_demo_setup.id, tfe_workspace.gcp_terraform_demo_setup.id ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "tfe_oauth_token_id" {
 
 variable "tfe_vcs_username" {
   description = "VCS username that will prefix the URL for all VCS actions"
-  default = "mtharpe"
+  default     = "mtharpe"
 }
 
 # AWS Variables

--- a/variables.tf
+++ b/variables.tf
@@ -2,11 +2,16 @@
 variable "tfe_api_key" {
   description = "Terraform Enterprise/Cloud API used to connect and configure workspaces"
 }
-variable "org_name" {
+variable "tfe_org_name" {
   description = "Terraform Enterprise/Cloud Organization name to create the workspaces in"
 }
-variable "oauth_token_id" {
+variable "tfe_oauth_token_id" {
   description = "Terraform Enterprise/Cloud VCS oauth token ID (found in settings/VCS)"
+}
+
+variable "tfe_vcs_username" {
+  description = "VCS username that will prefix the URL for all VCS actions"
+  default = "mtharpe"
 }
 
 # AWS Variables
@@ -23,20 +28,13 @@ variable "aws_region" {
   default     = "us-east-2"
 }
 
+# SSH Keys
 variable "public_key" {
   description = "Public key to connect to instances"
 }
 
 variable "private_key" {
   description = "Private key to connect to instances"
-}
-
-variable "instance_username" {
-  description = "Username to connect to instances"
-}
-
-variable "instance_password" {
-  description = "Password to connect to instances"
 }
 
 # GCP Variables
@@ -67,4 +65,13 @@ variable "azure_tenant_id" {
 
 variable "azure_client_secret" {
   description = "Azure Clinet Secret"
+}
+
+# Instance Information (mainly Azure Windows instances)
+variable "instance_username" {
+  description = "Username to connect to instances"
+}
+
+variable "instance_password" {
+  description = "Password to connect to instances"
 }


### PR DESCRIPTION
This update changes the vars to include VCS var so that you can point to another VCS repo with out a hard code of mtharpe as the repo location. Also, updated comments to be more clear about what they are, and cleaned up the naming so that each are consistent.

- [x] Terraform Validation Passed