### PR TITLE
Fix: attach policy sets via tfe_project_policy_set

### DIFF
--- a/sentinel.tf
+++ b/sentinel.tf
@@ -1,16 +1,14 @@
 locals {
-  sentinel_repo                = "mtharpe/terraform-sentinel-policies"
-  sentinel_repo_branch         = "main"
-  sentinel_policies_repo_owner = "mtharpe"
+  sentinel_repo        = "mtharpe/terraform-sentinel-policies"
+  sentinel_repo_branch = "main"
 }
 
 resource "tfe_policy_set" "aws" {
-  name         = "aws"
-  description  = "Sentinel policies applied to AWS project workspaces (cloud infra + cost guardrails)."
-  organization = var.tfe_org_name
-  kind         = "sentinel"
+  name          = "aws"
+  description   = "Sentinel policies applied to AWS project workspaces (cloud infra + cost guardrails)."
+  organization  = var.tfe_org_name
+  kind          = "sentinel"
   policies_path = "aws"
-  project_ids   = [tfe_project.aws.id]
 
   vcs_repo {
     identifier                 = local.sentinel_repo
@@ -18,15 +16,19 @@ resource "tfe_policy_set" "aws" {
     ingress_submodules         = false
     github_app_installation_id = var.github_app_installation_id
   }
+}
+
+resource "tfe_project_policy_set" "aws" {
+  project_id    = tfe_project.aws.id
+  policy_set_id = tfe_policy_set.aws.id
 }
 
 resource "tfe_policy_set" "vcs" {
-  name         = "vcs"
-  description  = "Sentinel policies applied to VCS project workspaces (GitHub/GitLab/TFE repo management)."
-  organization = var.tfe_org_name
-  kind         = "sentinel"
+  name          = "vcs"
+  description   = "Sentinel policies applied to VCS project workspaces (GitHub/GitLab/TFE repo management)."
+  organization  = var.tfe_org_name
+  kind          = "sentinel"
   policies_path = "vcs"
-  project_ids   = [tfe_project.vcs.id]
 
   vcs_repo {
     identifier                 = local.sentinel_repo
@@ -36,13 +38,17 @@ resource "tfe_policy_set" "vcs" {
   }
 }
 
+resource "tfe_project_policy_set" "vcs" {
+  project_id    = tfe_project.vcs.id
+  policy_set_id = tfe_policy_set.vcs.id
+}
+
 resource "tfe_policy_set" "admin" {
-  name         = "admin"
-  description  = "Sentinel policies applied to Admin project workspaces (TFE control plane)."
-  organization = var.tfe_org_name
-  kind         = "sentinel"
+  name          = "admin"
+  description   = "Sentinel policies applied to Admin project workspaces (TFE control plane)."
+  organization  = var.tfe_org_name
+  kind          = "sentinel"
   policies_path = "admin"
-  project_ids   = [tfe_project.admin.id]
 
   vcs_repo {
     identifier                 = local.sentinel_repo
@@ -50,4 +56,9 @@ resource "tfe_policy_set" "admin" {
     ingress_submodules         = false
     github_app_installation_id = var.github_app_installation_id
   }
+}
+
+resource "tfe_project_policy_set" "admin" {
+  project_id    = tfe_project.admin.id
+  policy_set_id = tfe_policy_set.admin.id
 }


### PR DESCRIPTION
## Summary
- The tfe provider does not accept `project_ids` directly on `tfe_policy_set`
- Drops `project_ids` from the AWS, VCS, and Admin policy sets
- Adds three `tfe_project_policy_set` resources attaching each policy set to its project

Fixes the `Error: Unsupported argument` on `project_ids`.

## Test plan
- [ ] `terraform plan` succeeds
- [ ] Plan creates 3 `tfe_policy_set` + 3 `tfe_project_policy_set` resources
- [ ] After apply, each policy set is attached to the correct project in HCP Terraform