### PR TITLE
Revert: remove Sentinel policy sets

### DIFF
--- a/sentinel.tf
+++ b/sentinel.tf
@@ -1,54 +1,13 @@
-locals {
-  sentinel_policies_path = "${path.module}/../terraform-sentinel-policies"
-}
+# resource "tfe_policy_set" "demo_sentinel_policy_set" {
+#   name          = "demo-policy-set"
+#   description   = "A brand new policy set for demos"
+#   organization  = var.tfe_org_name
+#   workspace_ids = [tfe_workspace.aws_terraform_demo_setup.id]
 
-data "tfe_slug" "aws" {
-  source_path = "${local.sentinel_policies_path}/aws"
-}
-
-data "tfe_slug" "vcs" {
-  source_path = "${local.sentinel_policies_path}/vcs"
-}
-
-data "tfe_slug" "admin" {
-  source_path = "${local.sentinel_policies_path}/admin"
-}
-
-resource "tfe_policy_set" "aws" {
-  name         = "aws"
-  description  = "Sentinel policies applied to AWS project workspaces (cloud infra + cost guardrails)."
-  organization = var.tfe_org_name
-  kind         = "sentinel"
-  slug         = data.tfe_slug.aws
-}
-
-resource "tfe_project_policy_set" "aws" {
-  project_id    = tfe_project.aws.id
-  policy_set_id = tfe_policy_set.aws.id
-}
-
-resource "tfe_policy_set" "vcs" {
-  name         = "vcs"
-  description  = "Sentinel policies applied to VCS project workspaces (GitHub/GitLab/TFE repo management)."
-  organization = var.tfe_org_name
-  kind         = "sentinel"
-  slug         = data.tfe_slug.vcs
-}
-
-resource "tfe_project_policy_set" "vcs" {
-  project_id    = tfe_project.vcs.id
-  policy_set_id = tfe_policy_set.vcs.id
-}
-
-resource "tfe_policy_set" "admin" {
-  name         = "admin"
-  description  = "Sentinel policies applied to Admin project workspaces (TFE control plane)."
-  organization = var.tfe_org_name
-  kind         = "sentinel"
-  slug         = data.tfe_slug.admin
-}
-
-resource "tfe_project_policy_set" "admin" {
-  project_id    = tfe_project.admin.id
-  policy_set_id = tfe_policy_set.admin.id
-}
+#   vcs_repo {
+#     identifier                 = "mtharpe/terraform-sentinel-common"
+#     branch                     = "main"
+#     ingress_submodules         = false
+#     github_app_installation_id = var.github_app_installation_id
+#   }
+# }


### PR DESCRIPTION
## Summary
- Removes the AWS, VCS, and Admin Sentinel policy sets added across #4, #5, and #6
- Restores `sentinel.tf` to the original commented-out demo stub
- Reason: HCP Terraform tier doesn't permit versioned (VCS-connected) policy sets, and slug-based sets require the policies repo to be accessible from the runner — which doesn't work for TFC runs

## Test plan
- [ ] `terraform plan` shows destruction of the 3 `tfe_policy_set` and 3 `tfe_project_policy_set` resources
- [ ] After apply, no policy sets remain attached to AWS / VCS / Admin projects in HCP Terraform
